### PR TITLE
2025-04-20 홍태선 / Boj12873

### DIFF
--- a/Boj12873.java
+++ b/Boj12873.java
@@ -1,0 +1,49 @@
+import java.util.Scanner;
+import java.util.List;
+import java.util.ArrayList;
+
+class Boj12873 {
+
+    public static void main(String[] args) {
+
+        Scanner sc = new Scanner(System.in);
+        Integer N = sc.nextInt();
+        if(!validate(N)) {
+            return;
+        }
+
+        int current_index = 0;
+        int pattern_len = N;
+        long stage = 1;
+        List<Integer> arr = new ArrayList<>();
+        for(int i = 0; i < N; i++) {
+            arr.add(i + 1);
+        }
+
+
+        // t=5000이면, t^3 == 1250억.. 근데 int 는 24억 정도..
+        while (arr.size() > 1) {
+            
+            long offset = (stage * stage * stage) % pattern_len;
+            
+            if(offset == 0) {
+                offset = pattern_len - 1;
+            } else {
+                offset -= 1;
+            }
+            int remove_index = (int)(current_index + offset) % pattern_len;
+            arr.remove(remove_index);
+            current_index = remove_index;
+            pattern_len--;
+            stage++;
+        }
+        System.out.println(arr.get(0));
+
+    }
+    private static boolean validate(Integer total) {
+        if(total == null || (total < 0 || total > 5000)) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
# 로직 설명
우선, 본 문제는 요세푸스 순열 문제라고 생각합니다. 그 이유는, 모듈러 연산을 사용해서 index bounding 을 계산하는 방식으로 해결할 수 있기 때문입니다. 

본 문제에서는 t^3 번을 모두 for 문으로 돌려서 해결하게 된다면, stage = 1 부터 시작하므로, stage 가 최대 5000번 까지 진행됩니다.
왜냐하면 리스트에서 한 명씩 제거되기 때문입니다. 따라서 최대 5000번 까지 stage 가 증가하게 되면, t^3 = 약 125억 정도 순회 해야 합니다. 
1초에 약 1억번 (c기준) 연산이 가능하다고 보면, 제한시간이 2초이내기 때문에 약 125초가 필요하여 시간안에 절대로 해결이 불가능 하다고 생각합니다.

한 명씩 배열에서 제거 되기 때문에 2명이 남을때 까지는 계산을 진행하지만, 2명에서 1명으로 줄게 되면 while 문에서 break 발생됩니다.
따라서 N -1 만큼 반복하게 되면서, 내부에서는 1^3 + 2^3 ... (t - 1)^3 만큼 계산을 진행하게 됩니다. 그럼 지수가 3승이 되어, 합공식을 이용하면 (t*(t+1) / 2)^2 인데, 이걸 계산하면 O(1/4t^4 + 1/4t^2) ≈ O(t^4) 이라 시간안에 순회해서 찾는 다는 것은 불가능합니다.

그래서 아이디어가 필요한데, 패턴을 찾을 수 있다는 것을 알 수 있습니다. 패턴 초기 길이를 = N 이라 하고, 한 명씩 제거 할 때마다 현재 위치에서 t^3 만큼 돌았을 때, 여러 번 돌고, 똑같은 구간을 지난다는 것을 알 수 있으면, 다시 처음 현재 위치까지 돌아오는 길이가 반복 길이로 볼 수 있습니다.

그래서 이것을 요세푸스 순열을 활용해서 t^3 을 패턴 길이로 모듈러 연산하여, 얻은 나머지에 - 1 하게 되면 삭제 할 인덱스를 구할 수 있습니다.

중요하다고 생각했던 것은, t^3 % pattern_len 에서, pattern_len 은 1씩 줄어들고, t^3 은 pattern_len 의 배수가 될 수 있다는 사실을 첫 번째 예제에서 알 수 있었습니다. t = 2 일 때, 8 % 2 = 0 인데, 이때 0 - 1 = -1 음수이므로 결국 len - 1 이 삭제할 대상 인덱스라는 사실을 알 수 있습니다. 하여 음수가 발생할 수 있다는 부분을 캐치하는게 중요하다고 생각했습니다. 

추가로, 디버깅 시간이 꽤 오래 걸린 부분이 자료형 범위였습니다. 생각해 보면, t^3 이 약 125억까지 계산이 되면 stage 변수는 int 를 아득히 뛰어넘습니다. int 형은 약 24억이니까요. 따라서 long 형태로 변경해야 하는데, 이때 주의해야 할 점은 stage 변수 자체를 long 으로 바꾸지 않고, 계산식에서만 변경하게 되면 틀리게 되는데, 그 이유는 stage 를 Math.pow 하지 않고 정수형 연산을 진행한 이유는 Math.pow 내부에는 부동소수점 오차로 인해 반올림 계산이 영향을 줄 수 있기 때문이며, 가장 큰 이유는 stage 를 세 번 곱셈하여 얻은 변수는 결국 계산내부에서 두 피연산자가 모두 int 형이므로 int 형 곱셈이 진행됩니다. 그래서 stage 또한 long 으로 선언 해야 합니다.

# 결론
요세푸스 순열 + 패턴 찾기 + 자료형 범위를 다루는 문제라고 생각합니다.
